### PR TITLE
Data preprocessing Changes, Fine Tuning, and Classification Report for Gaussian Naive Bayes

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import os
 
 from sklearn import preprocessing
 from sklearn.naive_bayes import GaussianNB, BernoulliNB, MultinomialNB, CategoricalNB
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import classification_report
 
 # Need to preprocess data first
 def preprocess(files_to_process, path, label):
@@ -41,10 +41,10 @@ def get_batch(batch_size, files, path, label):
             print("Found null image, skipping...")
             continue
         # First, resize image for consistency
-        resized = cv2.resize(img, (1080, 1080), interpolation=cv2.INTER_LINEAR)
+        resized = cv2.resize(img, (1080, 1080), interpolation=cv2.INTER_LANCZOS4)
         # Improve image contrast
         clahe = cv2.createCLAHE(clipLimit=3)
-        resized = clahe.apply(resized)
+        resized = np.clip(clahe.apply(resized)+15, 0, 255)
         # Reshape to fit with model
         flattened_img = resized.flatten()
         batch.append(flattened_img)
@@ -102,4 +102,4 @@ while len(test_pneumonia_bacterial_files) > 0:
     y_pred.extend(gnb.predict(batch))
     all_test_labels.extend(labels)
 
-print(accuracy_score(all_test_labels, y_pred))
+print(classification_report(all_test_labels, y_pred))

--- a/main.py
+++ b/main.py
@@ -42,6 +42,9 @@ def get_batch(batch_size, files, path, label):
             continue
         # First, resize image for consistency
         resized = cv2.resize(img, (1080, 1080), interpolation=cv2.INTER_LINEAR)
+        # Improve image contrast
+        clahe = cv2.createCLAHE(clipLimit=3)
+        resized = clahe.apply(resized)
         # Reshape to fit with model
         flattened_img = resized.flatten()
         batch.append(flattened_img)

--- a/main.py
+++ b/main.py
@@ -31,6 +31,26 @@ def preprocess(files_to_process, path, label):
     return (processed_files, labels)
 
 
+def get_batch(batch_size, files, path, label):
+    batch = []
+    labels = []
+    while len(files) > 0:
+        file = files.pop()
+        img = cv2.imread(os.path.join(path, file), cv2.IMREAD_GRAYSCALE)
+        if img is None:
+            print("Found null image, skipping...")
+            continue
+        # First, resize image for consistency
+        resized = cv2.resize(img, (1080, 1080), interpolation=cv2.INTER_LINEAR)
+        # Reshape to fit with model
+        flattened_img = resized.flatten()
+        batch.append(flattened_img)
+        labels.append(label)
+        if len(batch) >= batch_size:
+            break
+    return (batch, labels)
+
+
 training_dataset_dir_normal = "./chest_xray/train/NORMAL"
 training_dataset_dir_pneumonia = "./chest_xray/train/PNEUMONIA"
 
@@ -45,33 +65,38 @@ test_normal_files = [file for file in os.listdir(test_dataset_dir_normal) if isf
 test_pneumonia_virus_files = [file for file in os.listdir(test_dataset_dir_pneumonia) if (isfile(os.path.join(test_dataset_dir_pneumonia, file)) and "virus" in file)]
 test_pneumonia_bacterial_files = [file for file in os.listdir(test_dataset_dir_pneumonia) if (isfile(os.path.join(test_dataset_dir_pneumonia, file)) and "bacteria" in file)]
 
-processed_training_normal, label_normal = preprocess(all_files, training_dataset_dir_normal, 0)
-processed_training_pneumonia_viral, label_viral = preprocess(all_pneumonia_virus_files, training_dataset_dir_pneumonia, 1)
-processed_training_pneumonia_bacterial, label_bacterial = preprocess(all_pneumonia_bacterial_files, training_dataset_dir_pneumonia, 2)
-
-processed_test_normal, test_label_normal = preprocess(test_normal_files, test_dataset_dir_normal, 0)
-processed_test_pneumonia_viral, test_label_viral = preprocess(test_pneumonia_virus_files, test_dataset_dir_pneumonia, 1)
-processed_test_pneumonia_bacterial, test_label_bacterial = preprocess(test_pneumonia_bacterial_files, test_dataset_dir_pneumonia, 2)
-
-
-processed_training_normal.extend(processed_training_pneumonia_viral)
-processed_training_normal.extend(processed_training_pneumonia_bacterial)
-label_normal.extend(label_viral)
-label_normal.extend(label_bacterial)
-
-
-processed_test_normal.extend(processed_test_pneumonia_viral)
-processed_test_normal.extend(processed_test_pneumonia_bacterial)
-test_label_normal.extend(test_label_viral)
-test_label_normal.extend(test_label_bacterial)
-
-print(processed_training_normal)
-print(label_normal)
-
-
+BATCH_SIZE = 16
 
 gnb = GaussianNB()
-gnb.fit(processed_training_normal, label_normal)
-y_pred = gnb.predict(processed_test_normal)
+while len(all_files) > 0:
+    batch, labels = get_batch(BATCH_SIZE, all_files, training_dataset_dir_normal, 0)
+    gnb.partial_fit(batch, labels, classes=[0, 1, 2])
 
-print(accuracy_score(test_label_normal, y_pred))
+while len(all_pneumonia_virus_files) > 0:
+    batch, labels = get_batch(BATCH_SIZE, all_pneumonia_virus_files, training_dataset_dir_pneumonia, 1)
+    gnb.partial_fit(batch, labels)
+
+while len(all_pneumonia_bacterial_files) > 0:
+    batch, labels = get_batch(BATCH_SIZE, all_pneumonia_bacterial_files, training_dataset_dir_pneumonia, 2)
+    gnb.partial_fit(batch, labels)
+
+
+all_test_labels = []
+y_pred = []
+
+while len(test_normal_files) > 0:
+    batch, labels = get_batch(BATCH_SIZE, test_normal_files, test_dataset_dir_normal, 0)
+    y_pred.extend(gnb.predict(batch))
+    all_test_labels.extend(labels)
+
+while len(test_pneumonia_virus_files) > 0:
+    batch, labels = get_batch(BATCH_SIZE, test_pneumonia_virus_files, test_dataset_dir_pneumonia, 1)
+    y_pred.extend(gnb.predict(batch))
+    all_test_labels.extend(labels)
+
+while len(test_pneumonia_bacterial_files) > 0:
+    batch, labels = get_batch(BATCH_SIZE, test_pneumonia_bacterial_files, test_dataset_dir_pneumonia, 2)
+    y_pred.extend(gnb.predict(batch))
+    all_test_labels.extend(labels)
+
+print(accuracy_score(all_test_labels, y_pred))


### PR DESCRIPTION
This pull changes the preprocessing of the Gaussian Bayes model via improving image contrasting with CLAHE and changing the interpolation to INTER_LANCZOS4. The handling of the data was also changed to reduce RAM usage via batch loading and processing instead of loading the entire dataset into memory, allowing the images to be resized to 1080x1080 instead of 180x180

Other methods were tested, such as bluring the image and using cv2's HOG descriptor, seemed to lower the overall accuracy when tested, so these were left out in this pull

The reporting of data was also changed to include precision, recall, and f1-score, which revealed an important fact about the current state of the model described in the README (that it has trouble telling viral and bacterial pneumonia apart)